### PR TITLE
point to Jitsi Meet service, not to parent project

### DIFF
--- a/tools/00-index.md
+++ b/tools/00-index.md
@@ -30,4 +30,4 @@ Shared documents can really enable collaborative and participatory engagement op
 ## Video Conferencing 
 * Google Hangouts - Free 
 * Zoom - Paid
-* [Jitsi](https://jitsi.org) - Free
+* [Jitsi Meet](https://meet.jit.si/) - Free, browser-based


### PR DESCRIPTION
Also, because it's more privacy-friendly (no accounts) it should IMHO be recommended over Hangouts & Zoom. What do you think?